### PR TITLE
Feat: SignUp/SignIn

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -37,6 +37,7 @@ class UserManager(BaseUserManager):
 class Nation(models.Model):
     nation_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=100)
+    name_KR = models.CharField(max_length=100)
     image = models.ImageField(upload_to="")
 
 

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -10,23 +10,21 @@ from django.utils import timezone
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
-    def create_user(self, email, username, password, nation=None):
+    def create_user(self, email, password, nation=None):
         if not email:
             raise ValueError("The Email field must be set")
-        if not password:
-            raise ValueError("The Password field must be set")
 
         email = self.normalize_email(email)
-        user = self.model(email=email, username=username)
+        user = self.model(email=email, password=password)
         user.set_password(password)
         user.save(using=self._db)
         return user
 
-    def create_superuser(self, email, username, password, nation=None, **extra_fields):
+    def create_superuser(self, email, password, nation=None, **extra_fields):
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)
 
-        user = self.create_user(email=email, username=username, password=password)
+        user = self.create_user(email=email, password=password)
         user.is_superuser = True
         user.is_active = True
         user.is_staff = True
@@ -52,7 +50,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     school = models.CharField(verbose_name="학교", max_length=100)
     profile_image = models.ImageField(verbose_name="프로필 이미지", null=True, upload_to="")  # S3
     sns_link = models.CharField(verbose_name="sns 계정", max_length=100)
-    location = models.CharField(verbose_name="출신지", max_length=100)
+    gender = models.CharField(verbose_name="성별", max_length=1)
     token = models.CharField(max_length=100)
     is_staff = models.BooleanField(default=False)
     is_admin = models.BooleanField(default=False)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -16,6 +16,7 @@ class UserManager(BaseUserManager):
 
         email = self.normalize_email(email)
         user = self.model(email=email, password=password)
+        user.is_active = True
         user.set_password(password)
         user.save(using=self._db)
         return user
@@ -31,6 +32,24 @@ class UserManager(BaseUserManager):
         user.is_admin = True  
         user.set_password(password)
         user.save(using=self._db)
+        return user
+
+    def put_token(self, email, token):
+        user = User.objects.filter(email=email).update(token=token)         # save() 대신 update()
+        return user
+    
+    def activate(self, email):
+        user = User.objects.filter(email=email).update(is_allowed = True)
+        return user
+
+    def put_info(self, email, username, nation, birth, school, gender):
+        user = User.objects.filter(email=email).update(
+            username = username,
+            nation = nation,
+            birth = birth,
+            school = school,
+            gender = gender
+            )
         return user
 
 
@@ -50,12 +69,13 @@ class User(AbstractBaseUser, PermissionsMixin):
     birth = models.DateField(verbose_name="생년월일", null=True)
     school = models.CharField(verbose_name="학교", max_length=100)
     profile_image = models.ImageField(verbose_name="프로필 이미지", null=True, upload_to="")  # S3
-    sns_link = models.CharField(verbose_name="sns 계정", max_length=100)
+    sns_link = models.CharField(verbose_name="sns 계정", max_length=100, null=True)
     gender = models.CharField(verbose_name="성별", max_length=1)
-    token = models.CharField(max_length=100)
+    token = models.CharField(max_length=300)
     is_staff = models.BooleanField(default=False)
     is_admin = models.BooleanField(default=False)
     is_active = models.BooleanField(default=False)
+    is_allowed = models.BooleanField(default=False)
     date_joined = models.DateTimeField(auto_now=True)
 
     # User 커스터마이징할 때 User 식별용

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,5 +1,31 @@
+from rest_framework_simplejwt.serializers import RefreshToken
 from rest_framework import serializers
 from .models import User, Nation
+
+class RegisterSerializer(serializers.ModelSerializer):
+
+    email = serializers.EmailField(required=True)
+    password = serializers.CharField(required=True, write_only=True)
+
+    class Meta:
+        model = User
+        fields = ['id', 'email', 'password']
+
+    def create(self, validated_data):
+        user = User.objects.create_user(
+            email = self.validated_data['email'],
+            password = self.validated_data['password']
+        )
+
+        return user
+
+    def validate(self, data):
+        email = data.get('email', None)
+
+        if User.objects.filter(email=email).exists():
+            raise serializers.ValidationError('email already exists')
+        
+        return data
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -27,6 +27,42 @@ class RegisterSerializer(serializers.ModelSerializer):
         
         return data
 
+class AuthSerializer(serializers.ModelSerializer):
+
+    email = serializers.EmailField(required=True)
+    password = serializers.CharField(required=True, write_only=True)
+
+    class Meta:
+        model = User
+        fields = ['email', 'password']
+
+    def validate(self, data):
+        email = data.get('email', None)
+        password = data.get('password', None)
+
+        # Member DB에서 username과 일치하는 데이터 존재 여부
+        if User.objects.filter(email=email).exists():
+            user = User.objects.get(email=email)
+
+            # 데이터 존재하는데 password 불일치
+            if not user.check_password(password):
+                raise serializers.ValidationError("wrong password")
+        else:
+            raise serializers.ValidationError("member account not exists")
+
+        token = RefreshToken.for_user(user)
+        refresh_token = str(token)
+        access_token = str(token.access_token)
+
+        data = {
+            'user': user,
+            'refresh_token': refresh_token,
+            'access_token': access_token,
+        }
+
+        return data
+
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,8 +8,8 @@ urlpatterns = [
 
     #회원가입/로그인/로그아웃
     path('signup/', RegisterView.as_view()),
+    path('userInfo/', UserInfoView.as_view()),
     path('signin/', AuthView.as_view()),
-    path('logout/', LogoutView.as_view()),
 
     #토큰
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,4 +1,16 @@
 from django.urls import path
-from places.views import *
+from .views import *
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenVerifyView
 
-urlpatterns = []
+urlpatterns = [
+    # 이메일 중복 확인
+    path('email/<str:email>/', EmailVerificationView.as_view(), name='email_verification'),
+
+    #회원가입/로그인/로그아웃
+    path('signup/', RegisterView.as_view()),
+    # path('signin/', AuthView.as_view()),
+    #토큰
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,7 +8,9 @@ urlpatterns = [
 
     #회원가입/로그인/로그아웃
     path('signup/', RegisterView.as_view()),
-    # path('signin/', AuthView.as_view()),
+    path('signin/', AuthView.as_view()),
+    path('logout/', LogoutView.as_view()),
+
     #토큰
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,53 @@
-from django.shortcuts import render
+from django.http import JsonResponse
+from rest_framework_simplejwt.serializers import RefreshToken
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+from .serializers import RegisterSerializer, UserSerializer
+from .models import User
 
-# Create your views here.
+class EmailVerificationView(APIView):
+    serializer_class = UserSerializer
+
+    def get(self, request, email):
+        if User.objects.filter(email=email).exists():
+            res = Response({
+                "accept" : False,
+                "message" : "email alreay exists"
+            }, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            res = Response({
+                "accept" : True,
+                "message" : "can use email"
+            }, status=status.HTTP_200_OK)
+            
+        return res
+        
+class RegisterView(APIView):
+    serializer_class = RegisterSerializer
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+
+        if serializer.is_valid(raise_exception=False):
+            user = serializer.create(request)
+            token = RefreshToken.for_user(user)
+            refresh_token = str(token)
+            access_token = str(token.access_token)
+
+            res = Response(
+                {
+                    "user":serializer.data,
+                    "message":"register success",
+                    "token":{
+                        "access_token":access_token,
+                        "refresh_token":refresh_token,
+                    },
+                },
+                status=status.HTTP_201_CREATED,
+            )
+            return res
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -4,11 +4,10 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from django.shortcuts import get_object_or_404
-from .serializers import RegisterSerializer, UserSerializer
+from .serializers import RegisterSerializer, AuthSerializer
 from .models import User
 
 class EmailVerificationView(APIView):
-    serializer_class = UserSerializer
 
     def get(self, request, email):
         if User.objects.filter(email=email).exists():
@@ -50,4 +49,46 @@ class RegisterView(APIView):
             return res
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-        
+
+class AuthView(APIView):
+    serializer_class = AuthSerializer
+
+    def post(self, request):
+
+        serializer = self.serializer_class(data=request.data)
+						
+        if serializer.is_valid(raise_exception=False):
+            user = serializer.validated_data['user']
+            access_token = serializer.validated_data['access_token']
+            refresh_token = serializer.validated_data['refresh_token']
+            res = Response(
+                {
+                    "user": {
+                            "id":user.id,
+                            "email":user.email,
+                    },
+                    "message":"login success",
+                    "token":{
+                        "access_token":access_token,
+                        "refresh_token":refresh_token,
+                    },
+                },
+                status=status.HTTP_200_OK,
+            )
+            res.set_cookie("access-token", access_token, httponly=True)
+            res.set_cookie("refresh-token", refresh_token, httponly=True)
+            return res
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class LogoutView(APIView):
+    def delete(self, request):
+        res = Response({
+			"message":"logout success"
+		}, status=status.HTTP_202_ACCEPTED)
+				
+		# cookie에서 token 값들을 제거함
+        res.delete_cookie("access-token")
+        res.delete_cookie("refresh-token")
+        return res

--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,7 @@ PROJECT_APPS = [
 THIRD_PARTY_APPS = [
     'corsheaders',
     'rest_framework',
+    'rest_framework_simplejwt',
 ]
 
 
@@ -165,3 +166,24 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # User setting
 AUTH_USER_MODEL = 'accounts.User'
+
+
+# JWT
+
+from datetime import timedelta
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+}
+
+REST_USE_JWT = True
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=3),    # 유효기간 3시간
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),    # 유효기간 7일
+    'ROTATE_REFRESH_TOKENS': False,
+    'BLACKLIST_AFTER_ROTATION': False,
+    'TOKEN_USER_CLASS': 'accounts.User',
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
 asgiref==3.7.2
 Django==4.2.4
 django-cors-headers==4.2.0
+django-rest-framework==0.1.0
 djangorestframework==3.14.0
+djangorestframework-simplejwt==5.2.2
 gunicorn==21.2.0
 mysqlclient==2.2.0
 packaging==23.1
 Pillow==10.0.0
+PyJWT==2.8.0
 pytz==2023.3
 sqlparse==0.4.4
 tzdata==2023.3


### PR DESCRIPTION
## 📌 PR 내용
**이메일 인증 없이** 
### 1. 회원가입
- access_token, refresh_token 생성 후 refresh_token DB에 저장
### 2. 회원 정보 입력
- PUT 요청으로 정보 입력 -> is_allowed = True로 바뀌면서 회원정보 입력 여부 확인 및 정보 저장
### 3. 로그인
- refresh_token DB에 저장
### 4. Path Variable로 이메일 중복 여부 반환
---
### - 수정 사항
#### 1. create_user에 is_active=True 설정, is_allowed 속성 추가
- 모델 기본값이라 is_active=False면 삭제된 계정으로 인식해서 입력 여부 확인하는 새 속성 추가
#### 2. User 속성에 **location** 삭제, **gender** 추가

## ✨ 코드 요약
```accounts/models.py``` - User 모델 수정, Nation 모델에 한국어 추가
```accounts/serializers.py``` - RegisterSerializer(등록) , UserInfoSerializer(정보 입력), AuthSerializer(로그인)
```accounts/views.py``` - APIView 추가
```accounts/urls.py``` - URL 설정
```config/settings.py``` - jwt 설정

## 📚 이슈 및 레퍼런스
### Issue #6 

## 📸 스크린샷 (선택)
