### PR TITLE
Fix : post delete를 논리적 삭제로 변환

### DIFF
--- a/posts/models.py
+++ b/posts/models.py
@@ -20,12 +20,14 @@ class Post(BaseModel):
     interest = models.CharField(
         verbose_name="관심사", max_length=100, default=None, null=True
     )  # 디폴트 값 추가
+    is_deleted = models.BooleanField(default=False)  # 삭제 여부 확인
 
 
 class Post_KR(BaseModel):
     post = models.ForeignKey(Post, on_delete=models.CASCADE)
     title = models.CharField(verbose_name="한국어 제목", max_length=50)
     content = models.CharField(verbose_name="한국어 내용", max_length=200, default="")
+    is_deleted = models.BooleanField(default=False)
 
 
 class SavedPosts(models.Model):
@@ -33,6 +35,7 @@ class SavedPosts(models.Model):
     post_en = models.ForeignKey(Post, on_delete=models.CASCADE)
     post_kr = models.ForeignKey(Post_KR, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
+    is_deleted = models.BooleanField(default=False)
 
     class Meta:
         unique_together = ["user", "post_en", "post_kr"]  # 중복 스크랩 방지

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -18,45 +18,45 @@ from rest_framework.permissions import IsAuthenticated
 
 
 class GetPosts(APIView):
-    # 로그인이 되어 있어야만 접근 가능
     permission_classes = [IsAuthenticated]
 
     def get(self, request, userid):
-        # 게시물 불러오기
-        posts_en = Post.objects.filter(user_id=userid)
-        self.check_object_permissions(self.request, posts_en)
-        serializer_en = PostSerializer(posts_en, many=True)
+        try:
+            posts_en = Post.objects.filter(user_id=userid)
+            self.check_object_permissions(self.request, posts_en)
+            serializer_en = PostSerializer(posts_en, many=True)
 
-        # 한국어 게시물 데이터 처리 영어 게시물이 있을 때만 post_id를 통해 1:1 매칭
-        serializer_kr = None
-        if serializer_en.data:
-            post_id_list = [item["post_id"] for item in serializer_en.data]
-            posts_kr = Post_KR.objects.filter(post__post_id__in=post_id_list)
-            serializer_kr = Post_KRSerializer(posts_kr, many=True)
+            serializer_kr = None
+            if serializer_en.data:
+                post_id_list = [item["post_id"] for item in serializer_en.data]
+                posts_kr = Post_KR.objects.filter(post__post_id__in=post_id_list)
+                serializer_kr = Post_KRSerializer(posts_kr, many=True)
 
-        data = {
-            "post_en": serializer_en.data,
-            "post_kr": serializer_kr.data if serializer_kr else [],
-        }
-        if data:
+            data = {
+                "post_en": serializer_en.data,
+                "post_kr": serializer_kr.data if serializer_kr else [],
+            }
             return Response(data, status=status.HTTP_200_OK)
-        else:
-            return Response({"detail": "No posts"}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as e:
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class GetSavedPosts(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, userid):
-        # 게시물 불러오기
-        saved_posts = SavedPosts.objects.filter(user=userid)
-        self.check_object_permissions(self.request, saved_posts)
-        serializer_saved = SavedPostsSerializer(saved_posts, many=True)
+        try:
+            saved_posts = SavedPosts.objects.filter(user=userid)
+            self.check_object_permissions(self.request, saved_posts)
+            serializer_saved = SavedPostsSerializer(saved_posts, many=True)
 
-        data = {"post_en": serializer_saved.data}
-        if data:
+            data = {"post_en": serializer_saved.data}
             return Response(data, status=status.HTTP_200_OK)
-        else:
+
+        except Exception as e:
             return Response(
-                {"detail": "No saved posts"}, status=status.HTTP_404_NOT_FOUND
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )


### PR DESCRIPTION
## 📌 PR 내용
DELETE 기능을 데이터 삭제가 아닌 논리적 삭제로 변환
자잘한 에러처리

## ✨ 코드 요약
`posts/models.py` - Post, Post_KR, SavedPosts에 is_deleted 필드를 추가 (True 면 삭제된 게시글 or 스크랩)
`posts/views.py` - 삭제된 게시물인지 확인하는 과정 추가(is_deleted == True면 에러 처리, delete를 논리적 삭제로 변환 (is_deleted = True로 바꿔줌)
`profiles/views.py` - 에러처리 추가

## 📚 이슈 및 레퍼런스

#29 

## 📸 스크린샷 (선택)

