### PR TITLE
Fix: Token Refresh

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views import *
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenVerifyView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenVerifyView
 
 urlpatterns = [
     # 이메일 중복 확인
@@ -16,6 +16,6 @@ urlpatterns = [
 
     #토큰
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),
     path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
 ]


### PR DESCRIPTION
## 📌 PR 내용
refresh_token으로 access_token 재발급 받을 때 사용자 데이터 같이 넘겨주기

## ✨ 코드 요약
```accounts/serializers.py``` - 토큰 재발급 및 전달
```accounts/views.py``` - 사용자 데이터와 함께 전달
<!-- ```파일``` - 수정 내용 요약 -->

## 📚 이슈 및 레퍼런스
```venv\Lib\site-packages\rest_framework_simplejwt\views.py``` - TokenRefreshView, TokenViewBase
```venv\Lib\site-packages\rest_framework_simplejwt\serializers.py``` - TokenRefreshSerializer

## 📸 스크린샷 (선택)