### PR TITLE
Fix : posts DELETE 시 스크랩된 게시물도 삭제

### DIFF
--- a/posts/views.py
+++ b/posts/views.py
@@ -315,7 +315,9 @@ class PostDetail(APIView):
         try:
             post_en = get_object_or_404(Post, post_id=id)
             post_kr = get_object_or_404(Post_KR, post=post_en)
-
+            saved_post = SavedPosts.objects.get(
+                post_en=post_en.pk, user=request.user.id
+            )
             # 삭제된 posts인지 확인
             if post_en.is_deleted == True:
                 return Response(
@@ -331,6 +333,10 @@ class PostDetail(APIView):
 
             post_en.save()
             post_kr.save()
+
+            if saved_post:
+                saved_post.is_deleted = True
+                saved_post.save()
 
             return Response("DELETE complete", status=status.HTTP_204_NO_CONTENT)
         except Exception as e:

--- a/posts/views.py
+++ b/posts/views.py
@@ -342,7 +342,7 @@ class PostDetail(APIView):
         except Exception as e:
             return Response(
                 {"detail": f"An error occurred: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status=status.HTTP_404_NOT_FOUND,
             )
 
 


### PR DESCRIPTION
## 📌 PR 내용
posts DELETE 시 스크랩된 게시물도 삭제 처리 + 에러처리

## ✨ 코드 요약
`posts/views.py` - 스크랩된 게시물도 가져와서 is_delete = False로 바꿔줌

## 📚 이슈 및 레퍼런스


## 📸 스크린샷 (선택)

